### PR TITLE
Add max_connections parameter to approx::systemd_socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ add the urls you like to make available.
 
 A minimal example might be:
 
-~~~puppet
+~~~
 class{'approx'}
 
 approx::repository{'debian':
@@ -42,7 +42,7 @@ approx::repository{'debian-security':
 
 If you like to use hiera, you can define:
 
-~~~yaml
+~~~
 ---
 approx::config:
   debian:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ add the urls you like to make available.
 
 A minimal example might be:
 
-~~~
+~~~puppet
 class{'approx'}
 
 approx::repository{'debian':
@@ -42,7 +42,7 @@ approx::repository{'debian-security':
 
 If you like to use hiera, you can define:
 
-~~~
+~~~yaml
 ---
 approx::config:
   debian:
@@ -50,6 +50,17 @@ approx::config:
   debian-security:
       url: 'http://security.debian.org/debian-security'
 ~~~
+
+To set the listening address and port as well as the maximum number of connections for the systemd socket, use:
+
+~~~puppet
+class { 'approx::systemd_socket':
+  listen_streams  => ['0.0.0.0:3142'],
+  max_connections => 128,
+}
+~~~
+
+(Requires module version with `max_connections` support.)
 
 ## Systemd
 Newer debian systems using systemd use a systemd socket to configure the listening port/ip.

--- a/manifests/systemd_socket.pp
+++ b/manifests/systemd_socket.pp
@@ -20,6 +20,8 @@
 #  state of the service to ensure
 # @param service_enable
 #  if the service should be enabled or not
+# @param max_connections
+#   Optional. Sets the MaxConnections directive in the systemd socket unit.
 #
 class approx::systemd_socket (
   Optional[Array[String]] $listen_streams = undef,
@@ -27,6 +29,7 @@ class approx::systemd_socket (
   String[1]               $service_name   = 'approx.socket',
   String[1]               $service_ensure = 'running',
   Boolean                 $service_enable = true,
+  Optional[Integer]       $max_connections = undef,
 ) {
   if $listen_streams {
     systemd::dropin_file { 'approx.conf':
@@ -40,6 +43,9 @@ class approx::systemd_socket (
         ListenStream=<%= $v %> 
         <% } -%> 
         FreeBind=true
+        <% if $max_connections { -%>
+        MaxConnections=<%= $max_connections %>
+        <% } -%>
         |ENDTEMPLATE
       ),
     }


### PR DESCRIPTION
**Add max_connections parameter to approx::systemd_socket:**

`This PR adds an optional max_connections parameter to the approx::systemd_socket class, allowing users to set the MaxConnections directive in the systemd socket unit. This is useful for tuning the number of concurrent connections the socket will accept.`